### PR TITLE
Add calendar links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 List of all interesting dev usergroups in the Netherlands.
 
+Er is ook een [kalender overzicht](https://www.google.com/calendar/embed?src=services%40atimmer.com&ctz=Europe/Amsterdam ) en een [ical feed](https://www.google.com/calendar/ical/services%40atimmer.com/public/basic.ics).
+
 Zet je meetup groep, indien je vaste data hebt hieronder
 (in volgorde graag):
  


### PR DESCRIPTION
When working on organising PHPZwolle we found it hard to visualise which days of the month were still available, so I made this shared calendar to make it easier to visualise.

Second to last Tuesday of the month is hard to implement so I created it on the third Tuesday of the month and corrected the dates until August 2017.
